### PR TITLE
Add --hardwarnings flag to OpenSCAD command so the AI can see warnings.

### DIFF
--- a/src/openscad_mcp/server.py
+++ b/src/openscad_mcp/server.py
@@ -120,6 +120,7 @@ def render_scad_to_png(
         # Build OpenSCAD command
         cmd = [
             openscad_cmd,
+            "--hardwarnings",
             "-o", str(output_path),
             "--imgsize", f"{image_size[0]},{image_size[1]}",
             "--colorscheme", color_scheme,


### PR DESCRIPTION
Claude was generating SCAD code that produced warnings and empty renderings but the exit code from OpenSCAD was 0 without this flag.