### PR TITLE
fix: return images as MCP ImageContent so clients can display them

### DIFF
--- a/src/openscad_mcp/server.py
+++ b/src/openscad_mcp/server.py
@@ -18,7 +18,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 from fastmcp import Context, FastMCP
-from PIL import Image
+from fastmcp.utilities.types import Image as MCPImage
+from PIL import Image as PILImage
 import json
 
 logger = logging.getLogger(__name__)
@@ -733,7 +734,7 @@ def compress_base64_image(base64_data: str, quality: int = 85, optimize: bool = 
     try:
         # Decode base64 to image
         image_data = base64.b64decode(base64_data)
-        image = Image.open(io.BytesIO(image_data))
+        image = PILImage.open(io.BytesIO(image_data))
         
         # Compress using PNG optimization
         buffer = io.BytesIO()
@@ -907,10 +908,9 @@ async def render_single(
     variables: Optional[Dict[str, Any]] = None,
     auto_center: bool = False,
     quality: Optional[str] = None,
-    output_format: Optional[str] = "auto",
     include_paths: Optional[List[str]] = None,
     ctx: Optional[Context] = None,
-) -> Dict[str, Any]:
+):
     """
     Render a single view from OpenSCAD code or file.
 
@@ -926,12 +926,11 @@ async def render_single(
         variables: Variables to pass to OpenSCAD
         auto_center: Auto-center the model
         quality: Quality preset - "draft" (fast, low detail), "normal" (OpenSCAD defaults), or "high" (slow, high detail). User-provided variables override quality preset values.
-        output_format: Output format - "auto", "base64", "file_path", or "compressed" (default: "auto")
         include_paths: Additional include paths for OpenSCAD via -I flags, enabling multi-file project support
         ctx: MCP context for logging
 
     Returns:
-        Dict with base64-encoded PNG image or file path
+        List containing the rendered PNG image and metadata
     """
     if ctx:
         await ctx.info("Starting OpenSCAD render...")
@@ -986,7 +985,7 @@ async def render_single(
 
     try:
         # Run rendering in executor to avoid blocking the event loop
-        image_data = await asyncio.get_running_loop().run_in_executor(
+        image_b64 = await asyncio.get_running_loop().run_in_executor(
             None,
             render_scad_to_png,
             scad_content,
@@ -1004,43 +1003,26 @@ async def render_single(
         if ctx:
             await ctx.info("Rendering completed successfully")
 
-        # Apply response size management for single image
-        if output_format and output_format != "base64":
-            managed_result = manage_response_size(
-                {"render": image_data},
-                output_format=output_format,
-                max_size=20000,
-                ctx=ctx
-            )
-
-            # Check if we got extended format
-            if isinstance(managed_result, dict) and "render" in managed_result:
-                result_data = managed_result["render"]
-                if isinstance(result_data, dict):
-                    # Extended format with metadata
-                    return {
-                        "success": True,
-                        **result_data,  # Include type, data/path, mime_type
-                        "operation_id": str(uuid.uuid4()),
-                        "output_format": output_format if output_format != "auto" else "optimized"
-                    }
-
-        # Default base64 response (backwards compatible)
-        return {
-            "success": True,
-            "data": image_data,
-            "mime_type": "image/png",
-            "operation_id": str(uuid.uuid4()),
-        }
+        # Return as MCPImage so FastMCP sends proper ImageContent to clients
+        image_bytes = base64.b64decode(image_b64)
+        return [
+            MCPImage(data=image_bytes, format="png"),
+            json.dumps({
+                "success": True,
+                "operation_id": str(uuid.uuid4()),
+            }),
+        ]
 
     except Exception as e:
         if ctx:
             await ctx.error(f"Rendering failed: {str(e)}")
-        return {
-            "success": False,
-            "error": str(e),
-            "operation_id": str(uuid.uuid4()),
-        }
+        return [
+            json.dumps({
+                "success": False,
+                "error": str(e),
+                "operation_id": str(uuid.uuid4()),
+            })
+        ]
 
 
 @mcp.tool()
@@ -1052,10 +1034,9 @@ async def render_perspectives(
     color_scheme: Optional[str] = None,
     variables: Optional[Dict[str, Any]] = None,
     quality: Optional[str] = None,
-    output_format: Optional[str] = "auto",
     include_paths: Optional[List[str]] = None,
     ctx: Optional[Context] = None,
-) -> Dict[str, Any]:
+):
     """
     Render multiple standard views of an OpenSCAD model in a single call.
 
@@ -1076,15 +1057,12 @@ async def render_perspectives(
         quality: Quality preset - "draft" (fast, low detail), "normal" (OpenSCAD
             defaults), or "high" (slow, high detail). User-provided variables
             override quality preset values.
-        output_format: Output format - "auto", "base64", "file_path", or
-            "compressed" (default: "auto")
         include_paths: Additional include paths for OpenSCAD via -I flags,
             enabling multi-file project support
         ctx: MCP context for logging
 
     Returns:
-        Dict with success status, views dict mapping view names to image data
-        or file paths, count of rendered views, and output format used
+        List of rendered PNG images and metadata
     """
     try:
         # Validate input
@@ -1141,7 +1119,7 @@ async def render_perspectives(
             """Render a single view, returning (view_name, result_or_error)."""
             preset_pos, preset_target, preset_up = VIEW_PRESETS[view_name]
             try:
-                image_data = render_scad_to_png(
+                image_b64 = render_scad_to_png(
                     scad_content=scad_content,
                     scad_file=scad_file,
                     camera_position=list(preset_pos),
@@ -1153,7 +1131,7 @@ async def render_perspectives(
                     auto_center=True,
                     include_paths=include_paths,
                 )
-                return (view_name, {"success": True, "data": image_data})
+                return (view_name, {"success": True, "data": image_b64})
             except Exception as e:
                 return (view_name, {"success": False, "error": str(e)})
 
@@ -1166,66 +1144,45 @@ async def render_perspectives(
         results = await asyncio.gather(*tasks)
 
         # Collect successful renders and errors
-        successful_views = {}
+        response_items: list = []
         errors = {}
+        success_count = 0
         for view_name, result in results:
             if result["success"]:
-                successful_views[view_name] = result["data"]
+                image_bytes = base64.b64decode(result["data"])
+                response_items.append(f"View: {view_name}")
+                response_items.append(MCPImage(data=image_bytes, format="png"))
+                success_count += 1
             else:
                 errors[view_name] = result["error"]
 
-        # Apply response size management to successful views
-        resolved_format = output_format or "auto"
-        if successful_views:
-            managed_views = manage_response_size(
-                successful_views,
-                output_format=resolved_format,
-                max_size=25000,
-                ctx=ctx,
-            )
-        else:
-            managed_views = {}
-
-        # Merge errors into the views dict
-        view_results = dict(managed_views) if isinstance(managed_views, dict) else {}
-        for view_name, error_msg in errors.items():
-            view_results[view_name] = {"error": error_msg}
-
-        # Determine the actual output format used
-        if successful_views and isinstance(managed_views, dict):
-            sample = next(iter(managed_views.values()))
-            if isinstance(sample, dict) and "type" in sample:
-                actual_format = sample["type"]
-            elif isinstance(sample, str):
-                actual_format = "base64"
-            else:
-                actual_format = resolved_format
-        else:
-            actual_format = resolved_format
-
         if ctx:
-            success_count = len(successful_views)
             error_count = len(errors)
             msg = f"Rendered {success_count}/{len(views)} view(s) successfully"
             if error_count > 0:
                 msg += f" ({error_count} failed)"
             await ctx.info(msg)
 
-        return {
-            "success": len(errors) == 0,
-            "views": view_results,
-            "count": len(successful_views),
-            "errors": errors if errors else None,
-            "format": actual_format,
-        }
+        # Add metadata summary
+        response_items.append(
+            json.dumps({
+                "success": len(errors) == 0,
+                "count": success_count,
+                "errors": errors if errors else None,
+            })
+        )
+
+        return response_items
 
     except Exception as e:
         if ctx:
             await ctx.error(f"Render perspectives failed: {str(e)}")
-        return {
-            "success": False,
-            "error": str(e),
-        }
+        return [
+            json.dumps({
+                "success": False,
+                "error": str(e),
+            })
+        ]
 
 
 @mcp.tool
@@ -2508,7 +2465,7 @@ async def compare_renders(
     image_size: Optional[str] = None,
     quality: Optional[str] = "draft",
     ctx: Optional[Context] = None,
-) -> Dict[str, Any]:
+):
     """
     Render two versions of a model for visual comparison.
 
@@ -2538,8 +2495,7 @@ async def compare_renders(
         ctx: MCP context for logging
 
     Returns:
-        Dict with success status, before and after image data dicts,
-        view name, and quality preset used
+        List with before/after images and metadata
     """
     try:
         # Validate input combinations
@@ -2661,36 +2617,39 @@ async def compare_renders(
         after_task = loop.run_in_executor(
             None, _render_after
         )
-        before_data, after_data = await asyncio.gather(
+        before_b64, after_b64 = await asyncio.gather(
             before_task, after_task
         )
 
         if ctx:
             await ctx.info("Comparison renders completed")
 
-        return {
-            "success": True,
-            "before": {
-                "data": before_data,
-                "mime_type": "image/png",
-            },
-            "after": {
-                "data": after_data,
-                "mime_type": "image/png",
-            },
-            "view": view or "isometric",
-            "quality": quality or "draft",
-        }
+        before_bytes = base64.b64decode(before_b64)
+        after_bytes = base64.b64decode(after_b64)
+
+        return [
+            "Before:",
+            MCPImage(data=before_bytes, format="png"),
+            "After:",
+            MCPImage(data=after_bytes, format="png"),
+            json.dumps({
+                "success": True,
+                "view": view or "isometric",
+                "quality": quality or "draft",
+            }),
+        ]
 
     except Exception as e:
         if ctx:
             await ctx.error(
                 f"Comparison render failed: {str(e)}"
             )
-        return {
-            "success": False,
-            "error": str(e),
-        }
+        return [
+            json.dumps({
+                "success": False,
+                "error": str(e),
+            })
+        ]
 
 
 # ============================================================================

--- a/tests/test_openscad_mcp.py
+++ b/tests/test_openscad_mcp.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List
 # Add parent directory to path to import the server module
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
+from fastmcp.utilities.types import Image as MCPImage
 from openscad_mcp.server import (
     parse_list_param,
     parse_dict_param, 
@@ -386,7 +387,7 @@ class TestResponseSizeManagement:
             assert output_dir.exists()
             assert os.path.exists(file_path)
     
-    @patch('openscad_mcp.server.Image')
+    @patch('openscad_mcp.server.PILImage')
     def test_compress_base64_image(self, mock_image_class):
         """Test base64 image compression."""
         # Mock PIL Image
@@ -512,7 +513,7 @@ class TestIntegration:
         render_fn = render_single.fn if hasattr(render_single, 'fn') else render_single
 
         with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
-            mock_render.return_value = "base64imagedata"
+            mock_render.return_value = "AAAA"
 
             # Test with various parameter formats
             result = await render_fn(
@@ -525,8 +526,12 @@ class TestIntegration:
                 auto_center=True
             )
             
-            assert result["success"] is True
-            assert "data" in result or "path" in result
+            # Result is now a list: [MCPImage(...), '{"success": true, ...}']
+            assert isinstance(result, list)
+            assert len(result) == 2
+            assert isinstance(result[0], MCPImage)
+            metadata = json.loads(result[-1])
+            assert metadata["success"] is True
             
             # Verify parameters were parsed correctly
             call_args = mock_render.call_args[0]
@@ -541,7 +546,7 @@ class TestIntegration:
         render_fn = render_single.fn if hasattr(render_single, 'fn') else render_single
 
         with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
-            mock_render.return_value = "base64imagedata"
+            mock_render.return_value = "AAAA"
 
             # Test multiple views
             for view_name in ["front", "top", "isometric"]:
@@ -550,54 +555,55 @@ class TestIntegration:
                     view=view_name,
                     image_size=[800, 600],
                     variables={"radius": 10},
-                    output_format="base64"
                 )
                 
-                assert result["success"] is True
-                assert "data" in result
-                assert result["mime_type"] == "image/png"
+                # Result is now a list: [MCPImage(...), '{"success": true, ...}']
+                assert isinstance(result, list)
+                assert len(result) == 2
+                assert isinstance(result[0], MCPImage)
+                metadata = json.loads(result[-1])
+                assert metadata["success"] is True
     
     @pytest.mark.asyncio
-    async def test_render_with_output_format_auto(self):
-        """Test automatic output format selection based on size."""
+    async def test_render_single_returns_list_with_image(self):
+        """Test that render_single returns a list with MCPImage and metadata."""
         from openscad_mcp.server import render_single
         render_fn = render_single.fn if hasattr(render_single, 'fn') else render_single
 
-        # Small response
         with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
-            mock_render.return_value = "A" * 100  # Small image
+            mock_render.return_value = "AAAA"
+
+            result = await render_fn(scad_content="cube(5);")
+
+            # Result is a list: [MCPImage(...), '{"success": true, ...}']
+            assert isinstance(result, list)
+            assert len(result) == 2
+            assert isinstance(result[0], MCPImage)
+            metadata = json.loads(result[-1])
+            assert metadata["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_render_single_error_returns_list(self):
+        """Test that render_single error returns a list with JSON error metadata."""
+        from openscad_mcp.server import render_single
+        render_fn = render_single.fn if hasattr(render_single, 'fn') else render_single
+
+        with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
+            mock_render.side_effect = RuntimeError("OpenSCAD crashed")
 
             result = await render_fn(
-                scad_content="cube(5);",
-                output_format="auto"
+                scad_content="complex_model();",
+                view="isometric"
             )
-            
-            assert result["success"] is True
-            assert "data" in result  # Should use base64 for small images
-    
-    @pytest.mark.asyncio
-    async def test_render_with_large_response(self):
-        """Test handling of large responses with auto mode."""
-        from openscad_mcp.server import render_single
-        render_fn = render_single.fn if hasattr(render_single, 'fn') else render_single
 
-        with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
-            # Return very large image data
-            mock_render.return_value = "A" * 50000
-            
-            with tempfile.TemporaryDirectory() as tmpdir:
-                with patch('openscad_mcp.server.Path') as mock_path:
-                    mock_path.return_value = Path(tmpdir)
-                    
-                    result = await render_fn(
-                        scad_content="complex_model();",
-                        view="isometric",
-                        output_format="auto"
-                    )
-                    
-                    assert result["success"] is True
-                    # Should have handled the large response
-                    assert "operation_id" in result
+            # Error result is a list with a single JSON string
+            assert isinstance(result, list)
+            assert len(result) == 1
+            metadata = json.loads(result[0])
+            assert metadata["success"] is False
+            assert "OpenSCAD crashed" in metadata["error"]
+            assert "operation_id" in metadata
+
     
     def test_backward_compatibility(self):
         """Test that existing code using old API still works."""

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -247,7 +247,7 @@ class TestMemoryEfficiency:
         memory_used_mb = (peak - baseline) / 1024 / 1024
         assert memory_used_mb < 50, f"Used {memory_used_mb:.2f}MB, expected < 50MB"
     
-    @patch('openscad_mcp.server.Image')
+    @patch('openscad_mcp.server.PILImage')
     def test_compression_memory_efficiency(self, mock_image_class):
         """Test memory efficiency of compression."""
         import tracemalloc
@@ -349,7 +349,7 @@ class TestAsyncPerformance:
         render_fn = render_single.fn if hasattr(render_single, 'fn') else render_single
 
         with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
-            mock_render.return_value = "base64imagedata"
+            mock_render.return_value = "AAAA"
 
             # Create multiple render tasks
             tasks = []
@@ -366,7 +366,11 @@ class TestAsyncPerformance:
             elapsed = time.perf_counter() - start
 
             assert len(results) == 10
-            assert all(r["success"] for r in results)
+            # render_single returns a list; metadata is a JSON string as the last element
+            for r in results:
+                assert isinstance(r, list)
+                metadata = json.loads(r[-1])
+                assert metadata["success"]
             assert elapsed < 1.0, f"Concurrent renders took {elapsed}s"
 
     async def test_render_queue_performance(self):
@@ -377,7 +381,7 @@ class TestAsyncPerformance:
 
         with patch('openscad_mcp.server.render_scad_to_png') as mock_render:
             # Simulate varying render times
-            mock_render.side_effect = lambda *args: "base64data"
+            mock_render.side_effect = lambda *args: "AAAA"
 
             tasks = []
             views = ["front", "top", "isometric", "left", "right"]

--- a/tests/test_rendering_tools.py
+++ b/tests/test_rendering_tools.py
@@ -5,9 +5,12 @@ Covers quality presets, view presets, error handling, context logging,
 include path forwarding, and input validation.
 """
 
+import json
 import pytest
 from pathlib import Path
 from unittest.mock import patch, Mock, AsyncMock
+
+from fastmcp.utilities.types import Image as MCPImage
 
 from openscad_mcp.server import (
     render_single,
@@ -32,6 +35,11 @@ def _unwrap(tool):
     return tool.fn if hasattr(tool, "fn") else tool
 
 
+def _parse_metadata(result):
+    """Parse the JSON metadata string from the last element of a result list."""
+    return json.loads(result[-1])
+
+
 # ============================================================================
 # TestRenderSingleGaps
 # ============================================================================
@@ -49,17 +57,14 @@ class TestRenderSingleGaps:
 
     async def test_quality_draft(self):
         """Draft quality preset merges $fn/$fa/$fs into variables."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(scad_content="cube(10);", quality="draft")
 
-        assert result["success"] is True
-        call_kwargs = mock_render.call_args
-        variables = call_kwargs[1].get("variables") or call_kwargs[0][8] if len(call_kwargs[0]) > 8 else call_kwargs[1].get("variables")
-        # positional arg index 8 is variables; let's just check the call
-        # The function passes variables as a positional arg to render_scad_to_png
-        # render_scad_to_png is called via run_in_executor with positional args
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert isinstance(result[0], MCPImage)
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         args = mock_render.call_args[0]
         # args order: scad_content, scad_file, camera_position, camera_target,
         #             camera_up, image_size, color_scheme, variables, auto_center,
@@ -70,24 +75,22 @@ class TestRenderSingleGaps:
 
     async def test_quality_high(self):
         """High quality preset merges $fn/$fa/$fs into variables."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(scad_content="cube(10);", quality="high")
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         passed_vars = mock_render.call_args[0][7]
         for key, value in QUALITY_PRESETS["high"].items():
             assert passed_vars[key] == value
 
     async def test_quality_normal(self):
         """Normal quality preset adds no extra variables."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(scad_content="cube(10);", quality="normal")
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         passed_vars = mock_render.call_args[0][7]
         # normal preset is {}, so no quality keys
         assert "$fn" not in passed_vars
@@ -101,16 +104,15 @@ class TestRenderSingleGaps:
 
     async def test_user_variable_overrides_quality(self):
         """User-provided variable values override quality preset values."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(
                 scad_content="cube(10);",
                 quality="draft",
                 variables={"$fn": 100},
             )
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         passed_vars = mock_render.call_args[0][7]
         assert passed_vars["$fn"] == 100
 
@@ -118,12 +120,11 @@ class TestRenderSingleGaps:
 
     async def test_view_preset_front(self):
         """View preset 'front' sets correct camera parameters."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(scad_content="cube(10);", view="front")
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         args = mock_render.call_args[0]
         expected_pos, expected_target, expected_up = VIEW_PRESETS["front"]
         assert args[2] == list(expected_pos)
@@ -145,29 +146,28 @@ class TestRenderSingleGaps:
         ):
             result = await self.fn(scad_content="cube(10);")
 
-        assert result["success"] is False
-        assert "OpenSCAD crashed" in result["error"]
+        assert isinstance(result, list)
+        assert len(result) == 1
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "OpenSCAD crashed" in metadata["error"]
 
     async def test_ctx_logging(self, mock_context):
         """Context info method is called during render."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ):
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64):
             result = await self.fn(scad_content="cube(10);", ctx=mock_context)
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         mock_context.info.assert_called()
 
     async def test_include_paths_forwarded(self):
         """Include paths are forwarded to render_scad_to_png."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
-            result = await self.fn(
-                scad_content="cube(10);", include_paths=["/some/path"]
-            )
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
+            result = await self.fn(scad_content="cube(10);", include_paths=["/some/path"])
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         passed_include = mock_render.call_args[0][9]
         assert passed_include == ["/some/path"]
 
@@ -195,88 +195,69 @@ class TestRenderPerspectives:
 
     async def test_default_views(self):
         """Default views renders all 7 standard perspectives."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ):
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64):
             result = await self.fn(scad_content="cube(10);")
 
-        assert result["success"] is True
-        assert result["count"] == 7
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
+        assert metadata["count"] == 7
 
     async def test_custom_view_list(self):
         """Custom views list renders only the requested perspectives."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ):
-            result = await self.fn(
-                scad_content="cube(10);", views=["front", "top"]
-            )
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64):
+            result = await self.fn(scad_content="cube(10);", views=["front", "top"])
 
-        assert result["success"] is True
-        assert result["count"] == 2
-        assert "front" in result["views"]
-        assert "top" in result["views"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
+        assert metadata["count"] == 2
+        # Check that the view labels are present in the result list
+        labels = [item for item in result if isinstance(item, str) and item.startswith("View:")]
+        assert "View: front" in labels
+        assert "View: top" in labels
 
     async def test_views_as_csv_string(self):
         """Views provided as CSV string are parsed correctly."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ):
-            result = await self.fn(
-                scad_content="cube(10);", views=["front,top"]
-            )
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64):
+            result = await self.fn(scad_content="cube(10);", views=["front,top"])
 
-        # parse_list_param is called on the views list, but views is already
-        # a list, so it passes through. For a true CSV test, let's verify
-        # with a single-element list containing a CSV.
-        # Actually views is typed Optional[List[str]], but the code calls
-        # parse_list_param when views is not None, which handles lists directly.
-        # The CSV path is hit when views itself is a string, but the type
-        # signature says List[str]. Let's test the validation path instead.
         # With ["front,top"] it becomes a list with one element "front,top"
         # which is not in VIEW_PRESETS.
-        assert result["success"] is False
-        assert "Invalid view name" in result["error"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Invalid view name" in metadata["error"]
 
     async def test_views_parsed_as_list(self):
         """Explicit list of views renders only those perspectives."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ):
-            result = await self.fn(
-                scad_content="cube(10);", views=["front", "top"]
-            )
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64):
+            result = await self.fn(scad_content="cube(10);", views=["front", "top"])
 
-        assert result["success"] is True
-        assert result["count"] == 2
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
+        assert metadata["count"] == 2
 
     async def test_invalid_view(self):
         """Invalid view name in list returns error."""
-        result = await self.fn(
-            scad_content="cube(10);", views=["front", "nonexistent"]
-        )
+        result = await self.fn(scad_content="cube(10);", views=["front", "nonexistent"])
 
-        assert result["success"] is False
-        assert "Invalid view name" in result["error"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Invalid view name" in metadata["error"]
 
     async def test_partial_failure(self):
         """When one view fails, the others still succeed."""
         call_count = 0
 
-        def _mock_render(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            # Fail for second view
-            if call_count == 2:
-                raise RuntimeError("render failed")
-            return FAKE_B64
-
         def _mock_render_positional(
-            scad_content=None, scad_file=None,
-            camera_position=None, camera_target=None,
-            camera_up=None, image_size=None,
-            color_scheme="Cornfield", variables=None,
-            auto_center=False, include_paths=None,
+            scad_content=None,
+            scad_file=None,
+            camera_position=None,
+            camera_target=None,
+            camera_up=None,
+            image_size=None,
+            color_scheme="Cornfield",
+            variables=None,
+            auto_center=False,
+            include_paths=None,
         ):
             nonlocal call_count
             call_count += 1
@@ -288,27 +269,25 @@ class TestRenderPerspectives:
             "openscad_mcp.server.render_scad_to_png",
             side_effect=_mock_render_positional,
         ):
-            result = await self.fn(
-                scad_content="cube(10);", views=["front", "top"]
-            )
+            result = await self.fn(scad_content="cube(10);", views=["front", "top"])
 
+        metadata = _parse_metadata(result)
         # One succeeds, one fails
-        assert result["count"] == 1
-        assert result["errors"] is not None
-        assert len(result["errors"]) == 1
+        assert metadata["count"] == 1
+        assert metadata["errors"] is not None
+        assert len(metadata["errors"]) == 1
 
     async def test_quality_preset(self):
         """Quality preset variables are forwarded to render calls."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(
                 scad_content="cube(10);",
                 views=["front"],
                 quality="high",
             )
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         # Check that quality vars were passed in all calls
         for call_args in mock_render.call_args_list:
             kwargs = call_args[1]
@@ -318,48 +297,46 @@ class TestRenderPerspectives:
 
     async def test_both_inputs_error(self):
         """Providing both scad_content and scad_file returns error."""
-        result = await self.fn(
-            scad_content="cube(10);", scad_file="/some/file.scad"
-        )
+        result = await self.fn(scad_content="cube(10);", scad_file="/some/file.scad")
 
-        assert result["success"] is False
-        assert "Exactly one" in result["error"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Exactly one" in metadata["error"]
 
     async def test_no_input_error(self):
         """Providing neither scad_content nor scad_file returns error."""
         result = await self.fn()
 
-        assert result["success"] is False
-        assert "Exactly one" in result["error"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Exactly one" in metadata["error"]
 
     async def test_include_paths(self):
         """Include paths are forwarded to render_scad_to_png calls."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(
                 scad_content="cube(10);",
                 views=["front"],
                 include_paths=["/lib"],
             )
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         for call_args in mock_render.call_args_list:
             kwargs = call_args[1]
             assert kwargs.get("include_paths") == ["/lib"]
 
     async def test_ctx_logging(self, mock_context):
         """Context info method is called during render."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ):
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64):
             result = await self.fn(
                 scad_content="cube(10);",
                 views=["front"],
                 ctx=mock_context,
             )
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         mock_context.info.assert_called()
 
 
@@ -378,19 +355,20 @@ class TestCompareRenders:
 
     async def test_two_contents_mode(self):
         """Providing before and after SCAD content renders both."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(
                 scad_content_before="cube(10);",
                 scad_content_after="sphere(10);",
             )
 
-        assert result["success"] is True
-        assert "before" in result
-        assert "after" in result
-        assert result["before"]["data"] == FAKE_B64
-        assert result["after"]["data"] == FAKE_B64
+        assert isinstance(result, list)
+        assert len(result) == 5
+        assert result[0] == "Before:"
+        assert isinstance(result[1], MCPImage)
+        assert result[2] == "After:"
+        assert isinstance(result[3], MCPImage)
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         assert mock_render.call_count == 2
 
     async def test_file_with_variables_mode(self):
@@ -398,46 +376,54 @@ class TestCompareRenders:
         scad_file = self.tmp_path / "model.scad"
         scad_file.write_text("cube(size);")
 
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(
                 scad_file=str(scad_file),
                 variables_before={"size": 10},
                 variables_after={"size": 20},
             )
 
-        assert result["success"] is True
-        assert "before" in result
-        assert "after" in result
+        assert isinstance(result, list)
+        assert len(result) == 5
+        assert result[0] == "Before:"
+        assert isinstance(result[1], MCPImage)
+        assert result[2] == "After:"
+        assert isinstance(result[3], MCPImage)
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         assert mock_render.call_count == 2
 
     async def test_invalid_no_inputs(self):
         """Providing no valid input combination returns error."""
         result = await self.fn()
 
-        assert result["success"] is False
-        assert "Provide either" in result["error"]
+        assert isinstance(result, list)
+        assert len(result) == 1
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Provide either" in metadata["error"]
 
     async def test_invalid_only_before(self):
         """Providing only scad_content_before without after returns error."""
         result = await self.fn(scad_content_before="cube(10);")
 
-        assert result["success"] is False
-        assert "Provide either" in result["error"]
+        assert isinstance(result, list)
+        assert len(result) == 1
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Provide either" in metadata["error"]
 
     async def test_quality_merging(self):
         """Quality preset variables are merged into render calls."""
-        with patch(
-            "openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64
-        ) as mock_render:
+        with patch("openscad_mcp.server.render_scad_to_png", return_value=FAKE_B64) as mock_render:
             result = await self.fn(
                 scad_content_before="cube(10);",
                 scad_content_after="sphere(10);",
                 quality="draft",
             )
 
-        assert result["success"] is True
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is True
         for call_args in mock_render.call_args_list:
             kwargs = call_args[1]
             passed_vars = kwargs.get("variables", {})
@@ -455,8 +441,11 @@ class TestCompareRenders:
                 scad_content_after="sphere(10);",
             )
 
-        assert result["success"] is False
-        assert "OpenSCAD not found" in result["error"]
+        assert isinstance(result, list)
+        assert len(result) == 1
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "OpenSCAD not found" in metadata["error"]
 
     async def test_invalid_view(self):
         """Invalid view preset returns error."""
@@ -466,8 +455,9 @@ class TestCompareRenders:
             view="nonexistent",
         )
 
-        assert result["success"] is False
-        assert "Invalid view name" in result["error"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Invalid view name" in metadata["error"]
 
     async def test_invalid_quality(self):
         """Invalid quality preset returns error."""
@@ -477,5 +467,6 @@ class TestCompareRenders:
             quality="ultra",
         )
 
-        assert result["success"] is False
-        assert "Invalid quality preset" in result["error"]
+        metadata = _parse_metadata(result)
+        assert metadata["success"] is False
+        assert "Invalid quality preset" in metadata["error"]


### PR DESCRIPTION
## Summary

Rendering tools (`render_single`, `render_perspectives`, `compare_renders`) returned plain Python dicts with base64-encoded image data. FastMCP serialized these as `TextContent` (JSON text), so MCP clients like Claude Desktop received the image as a raw base64 string instead of a renderable image.

## Root Cause

FastMCP converts tool return values to MCP content blocks based on their type:
- `dict` → `TextContent` (JSON string) — **this is what was happening**
- `Image` → `ImageContent` (with `type: "image"`, `data`, `mimeType`) — **this is what should happen**

## Changes

- Import FastMCP `Image` as `MCPImage`, rename PIL `Image` to `PILImage`
- `render_single` now returns `[MCPImage(data=bytes, format="png"), metadata_json]`
- `render_perspectives` now returns `["View: name", MCPImage(...), ..., metadata_json]`
- `compare_renders` now returns `["Before:", MCPImage(...), "After:", MCPImage(...), metadata_json]`
- Remove return type annotations (`-> list`) to prevent FastMCP from generating an `output_schema`, which causes `pydantic_core.to_jsonable_python()` to fail on `Image` objects
- Remove `output_format` parameter from `render_single` and `render_perspectives` (no longer needed — FastMCP handles transport automatically)
- Update all tests for the new return format

## Testing

All 300 tests pass. Verified manually in Claude Desktop that images now render correctly.